### PR TITLE
Bump cascalog to to 1.10.1 - avoid heap space error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  [forma/gdal "1.8.0"]
                  [forma/jblas "1.2.1"]
                  [forma/forma "0.2.0-SNAPSHOT"]
-                 [cascalog "1.10.0"]
+                 [cascalog "1.10.1"]
                  [org.clojure/clojure-contrib "1.2.0"]
                  [cascalog-checkpoint "0.1.1"]
                  [backtype/dfs-datastores "1.1.3"]


### PR DESCRIPTION
@danhammer I remember seeing a heap space error a month or so ago, and I think it went away with Cascalog 1.10.1.

Check out [this commit](https://github.com/reddmetrics/forma-clj/commit/0d12aa50241ea2a70c372611f942e2028fc8b1b7): "Bump Cascalog to get newer Kryo dep w/o heap space error".
